### PR TITLE
Bumped kotlin and sql delight version

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     kotlin("android")
 }
 
-val composeVersion = "1.0.0"
+val composeVersion = "1.2.1"
 
 dependencies {
     implementation(project(":shared"))
@@ -25,11 +25,11 @@ dependencies {
 }
 
 android {
-    compileSdk = 31
+    compileSdk = 32
     defaultConfig {
         applicationId = "com.russhwolf.todo.androidApp"
         minSdk = 21
-        targetSdk = 31
+        targetSdk = 32
         versionCode = 1
         versionName = "1.0"
     }
@@ -53,6 +53,6 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = composeVersion
+        kotlinCompilerExtensionVersion = "1.4.6"
     }
 }

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -50,7 +50,7 @@ android {
 
     kotlinOptions {
         jvmTarget = "1.8"
-        useIR = true
+//        useIR = true
     }
 
     composeOptions {

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -50,7 +50,6 @@ android {
 
     kotlinOptions {
         jvmTarget = "1.8"
-//        useIR = true
     }
 
     composeOptions {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,9 +5,9 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.10")
-        classpath("com.android.tools.build:gradle:7.0.0")
-        classpath("com.squareup.sqldelight:gradle-plugin:1.5.1")
+        classpath("com.squareup.sqldelight:gradle-plugin:1.5.5")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.20")
+        classpath("com.android.tools.build:gradle:7.0.4")
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,3 +4,5 @@ android.useAndroidX=true
 #kotlin.mpp.enableGranularSourceSetsMetadata=true
 #kotlin.native.enableDependencyPropagation=false
 org.gradle.jvmargs=-Xmx2g
+
+kotlin.mpp.androidSourceSetLayoutVersion=1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/iosApp/ToDo.xcodeproj/project.pbxproj
+++ b/iosApp/ToDo.xcodeproj/project.pbxproj
@@ -310,7 +310,8 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd \"$SRCROOT/..\"\n./gradlew :shared:packForXCode -PXCODE_CONFIGURATION=${CONFIGURATION}\n";
+			shellScript = "
+";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/iosApp/ToDo.xcodeproj/project.pbxproj
+++ b/iosApp/ToDo.xcodeproj/project.pbxproj
@@ -310,8 +310,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "
-";
+			shellScript = "cd \"$SRCROOT/..\"\n./gradlew :shared:packForXCode -PXCODE_CONFIGURATION=${CONFIGURATION}\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -6,8 +6,8 @@ plugins {
     id("com.squareup.sqldelight")
 }
 
-val coroutineVersion = "1.5.0-native-mt"
-val sqldelightVersion = "1.5.0"
+val coroutineVersion = "1.6.4"
+val sqldelightVersion = "1.5.5"
 val turbineVersion = "0.5.1"
 
 group = "com.example"
@@ -35,18 +35,9 @@ kotlin {
         }
     }
     sourceSets {
-        // experimental opt-ins only in tests for Turbine usage
-        matching {
-            it.name.endsWith("Test")
-        }.configureEach {
-            languageSettings.useExperimentalAnnotation("kotlin.time.ExperimentalTime")
-            languageSettings.useExperimentalAnnotation("kotlinx.coroutines.ExperimentalCoroutinesApi")
-        }
-
         val commonMain by getting {
             dependencies {
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutineVersion")
-
                 implementation("com.squareup.sqldelight:coroutines-extensions:$sqldelightVersion")
             }
         }

--- a/shared/src/androidAndroidTest/kotlin/com/russhwolf/todo/shared/test/Utils.kt
+++ b/shared/src/androidAndroidTest/kotlin/com/russhwolf/todo/shared/test/Utils.kt
@@ -1,8 +1,8 @@
 package com.russhwolf.todo.shared.test
 
 import com.russhwolf.todo.shared.db.ToDoDatabase
-import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver
+import com.squareup.sqldelight.db.SqlDriver
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.runBlocking
 

--- a/shared/src/androidTest/kotlin/com/russhwolf/todo/shared/test/Utils.kt
+++ b/shared/src/androidTest/kotlin/com/russhwolf/todo/shared/test/Utils.kt
@@ -1,8 +1,8 @@
 package com.russhwolf.todo.shared.test
 
 import com.russhwolf.todo.shared.db.ToDoDatabase
-import com.squareup.sqldelight.db.SqlDriver
-import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.sqlite.driver.JdbcSqliteDriver
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.runBlocking
 

--- a/shared/src/commonTest/kotlin/com/russhwolf/todo/shared/test/Utils.kt
+++ b/shared/src/commonTest/kotlin/com/russhwolf/todo/shared/test/Utils.kt
@@ -1,6 +1,6 @@
 package com.russhwolf.todo.shared.test
 
-import com.squareup.sqldelight.db.SqlDriver
+import app.cash.sqldelight.db.SqlDriver
 import kotlinx.coroutines.CoroutineScope
 
 expect fun createTestDbDriver(): SqlDriver

--- a/shared/src/iosTest/kotlin/com/russhwolf/todo/shared/test/Utils.kt
+++ b/shared/src/iosTest/kotlin/com/russhwolf/todo/shared/test/Utils.kt
@@ -2,9 +2,9 @@ package com.russhwolf.todo.shared.test
 
 import co.touchlab.sqliter.DatabaseConfiguration
 import com.russhwolf.todo.shared.db.ToDoDatabase
-import com.squareup.sqldelight.db.SqlDriver
-import com.squareup.sqldelight.drivers.native.NativeSqliteDriver
-import com.squareup.sqldelight.drivers.native.wrapConnection
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.drivers.native.NativeSqliteDriver
+import app.cash.sqldelight.drivers.native.wrapConnection
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.runBlocking
 


### PR DESCRIPTION
I have upgrade to SQL Delight 1.5.5 and bumped kotlin to 1.8.20.
The examples for ios and android are also working.
Another PR to come which will use the new v2.x.x of SQL Delight
@russhwolf could you please review.